### PR TITLE
system的tools兼容

### DIFF
--- a/jeecg-boot/jeecg-boot-base/jeecg-boot-base-core/pom.xml
+++ b/jeecg-boot/jeecg-boot-base/jeecg-boot-base-core/pom.xml
@@ -179,6 +179,16 @@
 			</exclusions>
 		</dependency>
 
+		<!-- tools -->
+		<dependency>
+			<groupId>com.sun</groupId>
+			<artifactId>tools</artifactId>
+			<version>1.8.0</version>
+			<scope>system</scope>
+			<systemPath>${env.JAVA_HOME}/lib/tools.jar</systemPath>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- knife4j -->
 		<dependency>
 			<groupId>com.github.xiaoymin</groupId>


### PR DESCRIPTION
解决shiro-redis依赖本地jdk中的tools.jar编译报错