### PR TITLE
Could org.jeecgframework.boot:jeecg-boot-base-core:3.5.0 drop off redundant dependencies?

### DIFF
--- a/jeecg-boot-base-core/pom.xml
+++ b/jeecg-boot-base-core/pom.xml
@@ -44,6 +44,12 @@
 		<dependency>
 			<groupId>org.jeecgframework.boot</groupId>
 			<artifactId>jeecg-boot-common</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>lombok</artifactId>
+					<groupId>org.projectlombok</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!--集成springmvc框架并实现自动配置 -->
 		<dependency>
@@ -58,6 +64,16 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>jakarta.activation</artifactId>
+					<groupId>com.sun.activation</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>jakarta.mail</artifactId>
+					<groupId>com.sun.mail</groupId>
+				</exclusion>
+		      </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -123,6 +139,12 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<version>${mysql-connector-java.version}</version>
 			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>protobuf-java</artifactId>
+					<groupId>com.google.protobuf</groupId>
+				</exclusion>
+		        </exclusions>
 		</dependency>
 		<!--  sqlserver-->
 		<dependency>
@@ -144,12 +166,24 @@
 			<artifactId>postgresql</artifactId>
 			<version>${postgresql.version}</version>
 			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>checker-qual</artifactId>
+					<groupId>org.checkerframework</groupId>
+				</exclusion>
+		        </exclusions>
 		</dependency>
 
 		<!-- Quartz定时任务 -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-quartz</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>mchange-commons-java</artifactId>
+					<groupId>com.mchange</groupId>
+				</exclusion>
+		      </exclusions>
 		</dependency>
 
 		<!--JWT-->
@@ -175,6 +209,14 @@
 					<groupId>org.apache.shiro</groupId>
 					<artifactId>shiro-core</artifactId>
 				</exclusion>
+				<exclusion>
+					<artifactId>antlr4-runtime</artifactId>
+					<groupId>org.antlr</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>commons-cli</artifactId>
+					<groupId>commons-cli</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -183,6 +225,16 @@
 			<groupId>com.github.xiaoymin</groupId>
 			<artifactId>knife4j-spring-boot-starter</artifactId>
 			<version>${knife4j-spring-boot-starter.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>byte-buddy</artifactId>
+					<groupId>net.bytebuddy</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>classgraph</artifactId>
+					<groupId>io.github.classgraph</groupId>
+				</exclusion>
+			      </exclusions>
 		</dependency>
 
 		<!-- 代码生成器 -->
@@ -207,19 +259,38 @@
 					<artifactId>xercesImpl</artifactId>
 					<groupId>xerces</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>curvesapi</artifactId>
+					<groupId>com.github.virtuald</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>xerces</groupId>
-			<artifactId>xercesImpl</artifactId>
-			<version>2.12.2</version>
-			<optional>true</optional>
-		</dependency>
-
 		<!-- mini文件存储服务 -->
 		<dependency>
 			<groupId>io.minio</groupId>
 			<artifactId>minio</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>okio</artifactId>
+					<groupId>com.squareup.okio</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>okhttp</artifactId>
+					<groupId>com.squareup.okhttp3</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>error_prone_annotations</artifactId>
+					<groupId>com.google.errorprone</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>j2objc-annotations</artifactId>
+					<groupId>com.google.j2objc</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>checker-qual</artifactId>
+					<groupId>org.checkerframework</groupId>
+				</exclusion>
+		      </exclusions>
 		</dependency>
 
 		<!-- 阿里云短信 -->
@@ -233,15 +304,26 @@
 			<groupId>com.aliyun.oss</groupId>
 			<artifactId>aliyun-sdk-oss</artifactId>
 			<version>${aliyun.oss.version}</version>
-		</dependency>
-		<!-- 第三方登录  -->
-		<dependency>
-			<groupId>com.xkcoding.justauth</groupId>
-			<artifactId>justauth-spring-boot-starter</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>jaxb-api</artifactId>
+					<groupId>javax.xml.bind</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>stax-api</artifactId>
+					<groupId>stax</groupId>
+				</exclusion>
+			      </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>annotations</artifactId>
+					<groupId>org.jetbrains</groupId>
+				</exclusion>
+			      </exclusions>
 		</dependency>
 		<!-- 解决okhttp引用了kotlin,应用启动有警告日志问题 -->
 		<dependency>
@@ -251,6 +333,18 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-io</artifactId>
+					<groupId>commons-io</groupId>
+				</exclusion>
+      			</exclusions>
+		</dependency>
+		<dependency>
+		        <groupId>org.projectlombok</groupId>
+		        <artifactId>lombok</artifactId>
+		        <version>1.18.24</version>
+		        <scope>provided</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/126549527/231137928-ce8b7fed-cf40-4a34-a7cf-6cbf5dc20f48.png)
![image](https://user-images.githubusercontent.com/126549527/231138042-68bff3d3-f206-41e6-9dc2-b73a58a3b4b2.png)
![image](https://user-images.githubusercontent.com/126549527/231138234-4f14ed3c-f622-4c3e-a9a6-4b45f4077978.png)
![image](https://user-images.githubusercontent.com/126549527/231138338-84f71e3d-80c0-4ad1-94fc-1634b0a0a087.png)
![image](https://user-images.githubusercontent.com/126549527/231138449-dd326b28-4702-4455-af94-abf588e77826.png)
![image](https://user-images.githubusercontent.com/126549527/231138802-a6030e50-218c-4f96-9068-c2a2e23a5a88.png)
![image](https://user-images.githubusercontent.com/126549527/231138850-bc73f244-025d-4a0f-97da-9543b3f565c0.png)
![image](https://user-images.githubusercontent.com/126549527/231138996-97d4aa2b-ca2f-477a-85cc-756dab5d07e2.png)

Hi, I found that **_org.jeecgframework.boot:jeecg-boot-base-core:3.5.0_**’s pom file introduced **_251_** dependencies. However, among them, **_20_** libraries (**_8%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_11_**  redundant libraries have not been maintained by developers for more than **_3_** years（outdated dependencies）.

**_1_** redundant library has introduced an open source license conflict **_com.sun.mail:jakarta.mail:1.6.7_**. The dependent open source license is **_EPL 2.0_**(**_EPL 2.0_** cannot be used by the project with license **_Apache License, Version 2.0_**).

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with security vulnerabilities, outdated and open source license conflict. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code. 

This PR **_org.jeecgframework.boot:jeecg-boot-base-core:3.5.0_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
        com.xkcoding.justauth:justauth-spring-boot-starter:1.3.4:compile [24 KB]
        xerces:xercesImpl:2.12.2:compile [1 MB]
#### Redundant indirect dependencies:
        org.jetbrains:annotations:13.0:compile [17 KB]
        com.sun.activation:jakarta.activation:1.2.2:compile [66 KB]
        com.sun.mail:jakarta.mail:1.6.7:compile [660 KB]
        xml-apis:xml-apis:1.4.01:compile [215 KB]
        net.bytebuddy:byte-buddy:1.11.22:compile [3 MB]
        javax.xml.bind:jaxb-api:2.3.1:compile [125 KB]
        io.github.classgraph:classgraph:4.8.83:compile [492 KB]
        org.checkerframework:checker-qual:3.5.0:compile [209 KB]
        com.google.j2objc:j2objc-annotations:1.3:compile [8 KB]
        com.github.virtuald:curvesapi:1.06:compile [109 KB]
        stax:stax-api:1.0.1:compile [25 KB]
        commons-cli:commons-cli:1.4:compile [52 KB]
        org.antlr:antlr4-runtime:4.7:compile [326 KB]
        com.mchange:mchange-commons-java:0.2.15:compile [609 KB]
        com.google.errorprone:error_prone_annotations:2.3.4:compile [13 KB]
        me.zhyd.oauth:JustAuth:1.15.7:compile [214 KB]
        com.xkcoding.http:simple-http:1.0.2:compile [30 KB]
#### Redundant direct dependencies inherited from parent pom:
        org.projectlombok:lombok:1.18.24:compile [1 MB]

## Outdated dependencies
com.mchange:mchange-commons-java:0.2.15 (**_1894_** days without maintenance)
org.jetbrains:annotations:13.0 (**_3402_** days without maintenance)
com.sun.activation:jakarta.activation:1.2.2 (**_1145_** days without maintenance)
xml-apis:xml-apis:1.4.01 (**_4252_** days without maintenance)
stax:stax-api:1.0.1 (**_6066_** days without maintenance)
com.google.errorprone:error_prone_annotations:2.3.4 (**_1225_** days without maintenance)
commons-cli:commons-cli:1.4 (**_2224_** days without maintenance)
com.github.virtuald:curvesapi:1.06 (**_1857_** days without maintenance)
javax.xml.bind:jaxb-api:2.3.1 (**_1672_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.3 (**_2273_** days without maintenance)
org.antlr:antlr4-runtime:4.7 (**_2202_** days without maintenance)

## Open source license conflict dependencies
com.sun.mail:jakarta.mail:1.6.7
