### PR TITLE
网关路由配置Bug问题！！！

### DIFF
--- a/jeecg-server-cloud/jeecg-cloud-gateway/src/main/java/org/jeecg/loader/DynamicRouteLoader.java
+++ b/jeecg-server-cloud/jeecg-cloud-gateway/src/main/java/org/jeecg/loader/DynamicRouteLoader.java
@@ -21,6 +21,7 @@ import org.jeecg.config.RouterDataType;
 import org.jeecg.loader.repository.DynamicRouteService;
 import org.jeecg.loader.repository.MyInMemoryRouteDefinitionRepository;
 import org.jeecg.loader.vo.MyRouteDefinition;
+import org.jeecg.loader.vo.PredicatesVo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
@@ -35,10 +36,7 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.Executor;
 
 /**
@@ -207,7 +205,23 @@ public class DynamicRouteLoader implements ApplicationEventPublisherAware {
             }
             Object predicates = obj.get("predicates");
             if (predicates != null) {
-                JSONArray list = JSON.parseArray(predicates.toString());
+                
+                List<PredicatesVo> list = JSON.parseArray(predicates.toString(), PredicatesVo.class);
+                Map<String, List<String>> groupedPredicates = new HashMap<>();
+
+                for (PredicatesVo predicatesVo : list) {
+                    String name = predicatesVo.getName();
+                    List<String> args = predicatesVo.getArgs();
+                    groupedPredicates.computeIfAbsent(name, k -> new ArrayList<>()).addAll(args);
+                }
+
+                list = new ArrayList<>();
+                for (Map.Entry<String, List<String>> entry : groupedPredicates.entrySet()) {
+                    String name = entry.getKey();
+                    List<String> args = entry.getValue();
+                    list.add(new PredicatesVo(name, args));
+                }
+                
                 List<PredicateDefinition> predicateDefinitionList = new ArrayList<>();
                 for (Object map : list) {
                     JSONObject json = (JSONObject) map;

--- a/jeecg-server-cloud/jeecg-cloud-gateway/src/main/java/org/jeecg/loader/DynamicRouteLoader.java
+++ b/jeecg-server-cloud/jeecg-cloud-gateway/src/main/java/org/jeecg/loader/DynamicRouteLoader.java
@@ -224,7 +224,7 @@ public class DynamicRouteLoader implements ApplicationEventPublisherAware {
                 
                 List<PredicateDefinition> predicateDefinitionList = new ArrayList<>();
                 for (Object map : list) {
-                    JSONObject json = (JSONObject) map;
+                    JSONObject json = JSON.parseObject(JSON.toJSONString(map));
                     PredicateDefinition predicateDefinition = new PredicateDefinition();
                     //update-begin-author:zyf date:20220419 for:【VUEN-762】路由条件添加异常问题,原因是部分路由条件参数需要设置固定key
                     String name=json.getString("name");

--- a/jeecg-server-cloud/jeecg-cloud-gateway/src/main/java/org/jeecg/loader/vo/PredicatesVo.java
+++ b/jeecg-server-cloud/jeecg-cloud-gateway/src/main/java/org/jeecg/loader/vo/PredicatesVo.java
@@ -1,0 +1,16 @@
+package org.jeecg.loader.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PredicatesVo {
+    private String  name;
+    private List<String> args;
+}


### PR DESCRIPTION
##### 版本号： 3.5.3


##### 前端版本：vue3版


##### 问题描述：
网关路由配置时，如果前端添加了相同name的路由条件（比如添加了两个Path，如下图），就会出现配置失效的问题。(经过测试，添加多个相同的路由条件，最后一个会生效其他都会生效),

解决方案：将多个配置list整合为一个，保证相同name的配置只有一个配置对象，代码如下图

##### 截图&代码：

![image](https://github.com/jeecgboot/jeecg-boot/assets/92191856/078eb00f-14aa-4eed-8a25-a837f761c81d)
![image](https://github.com/jeecgboot/jeecg-boot/assets/92191856/a89c3525-5185-462a-b3be-6bb028764ac3)


