### PR TITLE
fix issue for springboot3 #5741: shiro 无法使用 spring boot 3.X 自带的jedis，降版本处理

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,13 @@
 				<version>${jeecgboot.version}</version>
 			</dependency>
 
+			<!-- shiro 无法使用 spring boot 3.X 自带的jedis，降版本处理 -->
+			<dependency>
+				<groupId>redis.clients</groupId>
+				<artifactId>jedis</artifactId>
+				<version>2.9.0</version>
+			</dependency>
+
 			<!-- jeecg tools -->
 			<dependency>
 				<groupId>org.jeecgframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
 		<justauth-spring-boot-starter.version>1.3.4</justauth-spring-boot-starter.version>
 		<dom4j.version>1.6.1</dom4j.version>
 		<qiniu-java-sdk.version>7.4.0</qiniu-java-sdk.version>
+		<jedis.version>2.9.0</jedis.version>
 		<!-- Log4j2爆雷漏洞 -->
 		<!-- spring boot 3 不支持下列两个版本-->
 		<!--<log4j2.version>2.17.0</log4j2.version>
@@ -166,13 +167,6 @@
 				<groupId>org.jeecgframework.boot</groupId>
 				<artifactId>jeecg-system-biz</artifactId>
 				<version>${jeecgboot.version}</version>
-			</dependency>
-
-			<!-- shiro 无法使用 spring boot 3.X 自带的jedis，降版本处理 -->
-			<dependency>
-				<groupId>redis.clients</groupId>
-				<artifactId>jedis</artifactId>
-				<version>2.9.0</version>
 			</dependency>
 
 			<!-- jeecg tools -->


### PR DESCRIPTION
fix issue for springboot3 #5741: shiro 无法使用 spring boot 3.X 自带的jedis，降版本处理