### PR TITLE
fix:pg数据库querySysCementListByUserId执行异常

### DIFF
--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/mapper/xml/SysAnnouncementMapper.xml
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/mapper/xml/SysAnnouncementMapper.xml
@@ -37,7 +37,7 @@
 	   where send_status = '1' 
 	   and del_flag = '0' 
 	   and msg_category = #{msgCategory} 
-	   and id IN ( select annt_id from sys_announcement_send where user_id = #{userId} and read_flag = 0)
+	   and id IN ( select annt_id from sys_announcement_send where user_id = #{userId} and read_flag = '0')
 	   order by create_time DESC
 	</select>
 


### PR DESCRIPTION
fix:pg数据库querySysCementListByUserId执行异常
```
2024-04-21 19:40:30.314 [http-nio-8080-exec-4] ERROR o.jeecg.common.exception.JeecgBootExceptionHandler:78 - 
### Error querying database.  Cause: org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
  Position: 216
### The error may exist in file [/Users/widder/IdeaProjects/jeecg-boot/jeecg-module-system/jeecg-system-biz/target/classes/org/jeecg/modules/system/mapper/xml/SysAnnouncementMapper.xml]
### The error may involve org.jeecg.modules.system.mapper.SysAnnouncementMapper.querySysCementListByUserId-Inline
### The error occurred while setting parameters
### SQL: SELECT COUNT(*) AS total FROM sys_announcement WHERE send_status = '1' AND del_flag = '0' AND msg_category = CAST(? AS varchar) AND id IN (SELECT annt_id FROM sys_announcement_send WHERE user_id = ? AND read_flag = 0)
### Cause: org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
  Position: 216
; bad SQL grammar []; nested exception is org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
  Position: 216
org.springframework.jdbc.BadSqlGrammarException: 
### Error querying database.  Cause: org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
  Position: 216
### The error may exist in file [/Users/widder/IdeaProjects/jeecg-boot/jeecg-module-system/jeecg-system-biz/target/classes/org/jeecg/modules/system/mapper/xml/SysAnnouncementMapper.xml]
### The error may involve org.jeecg.modules.system.mapper.SysAnnouncementMapper.querySysCementListByUserId-Inline
### The error occurred while setting parameters
### SQL: SELECT COUNT(*) AS total FROM sys_announcement WHERE send_status = '1' AND del_flag = '0' AND msg_category = CAST(? AS varchar) AND id IN (SELECT annt_id FROM sys_announcement_send WHERE user_id = ? AND read_flag = 0)
### Cause: org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
  Position: 216
; bad SQL grammar []; nested exception is org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
  Position: 216

```